### PR TITLE
Make 'mu register --all' recursive (fixes: #13).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,9 @@ Then go to the root directory containing the repositories
 (in this case ``cd /workspace``), add the repositories you want 
 to work with and issue commands to all registered repos.
 
-**Tip:** ``mu register --all`` registers all sub directories that contain
-a ``.git`` subdirectory.
+**Tip:** ``mu register --recursive`` registers all sub directories that contain
+a ``.git`` subdirectory. To register only sub directories within the current
+directory, issue ``mu register --current``.
 
 **Note:** it may also be used as a git replacement on directories 
 containing a ``.git`` dir.
@@ -90,8 +91,10 @@ Commands
 ~~~~~~~~
 
 * ``mu register repo1 repo2`` 
-    Registers repo1 and repo2 to be tracked. Also accepts an ``--all`` parameter, that automatically
-    adds all repositories found in the current directory (but not recursively).
+    Registers repo1 and repo2 to be tracked. Also accepts a ``--all`` or
+    ``--current`` parameter, that automatically adds all repositories found in
+    the current directory (but not recursively). To automatically add all
+    repositories recursively, use ``--recursive``.
 
 * ``mu unregister repo1 repo2``
     Unregisters previously tracked repositories (also accepts ``--all``).

--- a/mu_repo/__docs__.py
+++ b/mu_repo/__docs__.py
@@ -1,14 +1,16 @@
 '''mu-repo is a command-line utility to deal with multiple git repositories.
-        
-It works with a .mu_repo file in the current working dir which provides the 
+
+It works with a .mu_repo file in the current working dir which provides the
 configuration of the directories that should be tracked on commands
-(it may also be used as a git replacement on directories containing a 
+(it may also be used as a git replacement on directories containing a
 .git dir).
 
 Commands:
 
 * ${START_COLOR}mu register repo1 repo2:${RESET_COLOR} Registers repo1 and repo2 to be tracked.
-* ${START_COLOR}mu register --all:${RESET_COLOR} Registers all subdirs with .git.
+* ${START_COLOR}mu register --all:${RESET_COLOR} Registers all subdirs with .git (non-recursive).
+* ${START_COLOR}mu register --current:${RESET_COLOR} Registers all subdirs with .git (non-recursive).
+* ${START_COLOR}mu register --recursive:${RESET_COLOR} Registers all subdirs with .git (recursive).
 * ${START_COLOR}mu unregister repo1 repo2 | --all:${RESET_COLOR} Stops tracking some repository.
 * ${START_COLOR}mu list:${RESET_COLOR} Lists the currently tracked repositories.
 * ${START_COLOR}mu set-var git=d:/bin/git/bin/git.exe:${RESET_COLOR} Set git location to be used.
@@ -19,31 +21,31 @@ Commands:
 * ${START_COLOR}mu fix-eol:${RESET_COLOR} Changes end of lines to '\\n' on all changed files.
 * ${START_COLOR}mu find-branch [-r] *pat*:${RESET_COLOR} Finds all branches matching a given pattern (or simply mu fb).
 * ${START_COLOR}mu install:${RESET_COLOR} Initial configuration git (username, log, etc.)
-* ${START_COLOR}mu auto-update:${RESET_COLOR} Automatically updates mu-repo 
+* ${START_COLOR}mu auto-update:${RESET_COLOR} Automatically updates mu-repo
   (using git -- must have been pulled from git as in the instructions).
 
 * ${START_COLOR}mu dd:${RESET_COLOR}
-     Creates a directory structure with working dir vs head and opens 
+     Creates a directory structure with working dir vs head and opens
      WinMerge with it (doing mu ac will commit exactly what's compared in this
      situation).
-     
+
      Also accepts a parameter to compare with a different commit/branch. I.e.:
      mu dd HEAD^^
      mu dd 9fd88da
      mu dd development
 
 Specifying a repository for a single command (repo: argument):
-   e.g.: ${START_COLOR}mu st repo:repo1,repo2${RESET_COLOR}: Will do st on repo1 and repo2.  
+   e.g.: ${START_COLOR}mu st repo:repo1,repo2${RESET_COLOR}: Will do st on repo1 and repo2.
 
 
-* ${START_COLOR}mu group:${RESET_COLOR} Repository grouping 
+* ${START_COLOR}mu group:${RESET_COLOR} Repository grouping
 
   * ${START_COLOR}mu group add <name> [--empty]:${RESET_COLOR} Creates new group using current repositories, unless --empty is given
   * ${START_COLOR}mu group rm <name>:${RESET_COLOR} Removes a group
   * ${START_COLOR}mu group switch <name>:${RESET_COLOR} Switches to an existing group
   * ${START_COLOR}mu group reset:${RESET_COLOR} Stops using the current group (uses all repos again).
   * ${START_COLOR}mu group:${RESET_COLOR} With no parameters, just lists current groups
-  
+
   Use ${START_COLOR}mu register${RESET_COLOR} normally to add repositories to the current group
   Use ${START_COLOR}mu list${RESET_COLOR} to list repositories in the current group
 
@@ -52,13 +54,13 @@ Shortcuts:
 
 ${START_COLOR}mu st         ${RESET_COLOR}= Nice status message for all repos (always in parallel)
 ${START_COLOR}mu co branch  ${RESET_COLOR}= git checkout branch
-${START_COLOR}mu mu-patch   ${RESET_COLOR}= git diff --cached --full-index > output to file for each repo 
+${START_COLOR}mu mu-patch   ${RESET_COLOR}= git diff --cached --full-index > output to file for each repo
 ${START_COLOR}mu mu-branch  ${RESET_COLOR}= git rev-parse --abbrev-ref HEAD (print current branch)
-${START_COLOR}mu up         ${RESET_COLOR}= git fetch origin curr_branch:refs/remotes/origin/curr_branch 
+${START_COLOR}mu up         ${RESET_COLOR}= git fetch origin curr_branch:refs/remotes/origin/curr_branch
 ${START_COLOR}mu upd | sync ${RESET_COLOR}= up/diff incoming changes
 ${START_COLOR}mu a          ${RESET_COLOR}= git add -A
 ${START_COLOR}mu c msg      ${RESET_COLOR}= git commit -m "Message" (the message must always be passed)
-${START_COLOR}mu ac msg     ${RESET_COLOR}= git add -A & git commit -m (the message must always be passed) 
+${START_COLOR}mu ac msg     ${RESET_COLOR}= git add -A & git commit -m (the message must always be passed)
 ${START_COLOR}mu acp msg    ${RESET_COLOR}= same as 'mu ac' + git push origin current branch.
 ${START_COLOR}mu p          ${RESET_COLOR}= git push origin current branch.
 ${START_COLOR}mu rb         ${RESET_COLOR}= git rebase origin/current branch.

--- a/mu_repo/action_register.py
+++ b/mu_repo/action_register.py
@@ -21,11 +21,17 @@ def Run(params):
     join = os.path.join
     isdir = os.path.isdir
     if '--all' in args:
-        if len(args) > 1:
-            Print('If --all is passed in mu register, no other parameter should be passed.')
+        if [arg for arg in args if not arg.startswith('--')]:
+            Print('If --all is passed in mu register, no other dir names should be passed.')
             return
 
-        args = [repo for repo in os.listdir('.') if isdir(join(repo, '.git'))]
+        args = []
+        for root, directories, filenames in os.walk('.'):
+            if '.git' in directories:
+                directories.remove('.git')
+            for directory in directories:
+                if isdir(os.path.join(root, directory, '.git')):
+                    args.append(os.path.relpath(os.path.join(root, directory)))
 
     new_args = []
     for arg in args:

--- a/mu_repo/action_register.py
+++ b/mu_repo/action_register.py
@@ -12,7 +12,7 @@ def Run(params):
     config = params.config
 
     if len(args) < 2:
-        msg = 'Repository (dir name|--all) to track not passed'
+        msg = 'Repository (dir name|--all|--current|--recursive) to track not passed'
         Print(msg)
         return Status(msg, False)
     repos = config.repos
@@ -20,18 +20,22 @@ def Run(params):
     args = args[1:]
     join = os.path.join
     isdir = os.path.isdir
-    if '--all' in args:
+    # Either accept options or dir names, but not both.
+    if '--all' in args or '--current' in args or '--recursive' in args:
         if [arg for arg in args if not arg.startswith('--')]:
-            Print('If --all is passed in mu register, no other dir names should be passed.')
+            Print('If an option is passed in mu register, no other dir names should be passed.')
             return
 
-        args = []
-        for root, directories, filenames in os.walk('.'):
-            if '.git' in directories:
-                directories.remove('.git')
-            for directory in directories:
-                if isdir(os.path.join(root, directory, '.git')):
-                    args.append(os.path.relpath(os.path.join(root, directory)))
+        if '--all' in args or '--current' in args:
+            args = [repo for repo in os.listdir('.') if isdir(join(repo, '.git'))]
+        elif '--recursive' in args:
+            args = []
+            for root, directories, filenames in os.walk('.'):
+                if '.git' in directories:
+                    directories.remove('.git')
+                for directory in directories:
+                    if isdir(os.path.join(root, directory, '.git')):
+                        args.append(os.path.relpath(os.path.join(root, directory)))
 
     new_args = []
     for arg in args:


### PR DESCRIPTION
As already explained in the help output for 'mu register --all', all
subdirectories containing a .git directory are added to the .mu_repo
file.