### PR TITLE
Added the argument --all to clone sub-command

### DIFF
--- a/mu_repo/action_clone.py
+++ b/mu_repo/action_clone.py
@@ -59,7 +59,7 @@ def Run(params):
         Print('Opening http://fabioz.github.io/mu-repo/cloning/ for help on cloning...')
         return        
     elif len(args) == 1 and args[0] == '--all':
-        Print("cloning all registered repos...")
+        Print("Cloning all registered repos...")
         repos = params.config.repos
     else:
         for arg in args:

--- a/mu_repo/action_clone.py
+++ b/mu_repo/action_clone.py
@@ -43,21 +43,23 @@ def Run(params):
     assert args[0] == 'clone'
     args = args[1:]
     
+    repos = []
+    other_cmd_line_args = []
+    
     if len(args) == 1 and args[0] == '--help':
         import webbrowser
         webbrowser.open("http://fabioz.github.io/mu-repo/cloning/")
         Print('Opening http://fabioz.github.io/mu-repo/cloning/ for help on cloning...')
-        return
-
-    repos = []
-    other_cmd_line_args = []
-
-    for arg in args:
-        if not arg.startswith('-') and not '@' in arg and not ':' in arg and not '/' in arg:
-            repos.append(arg)
-        else:
-            other_cmd_line_args.append(arg)
-
+        return        
+    elif len(args) == 1 and args[0] == '--all':
+        Print("cloning all registered repos...")
+        repos = params.config.repos
+    else:
+        for arg in args:
+            if not arg.startswith('-') and not '@' in arg and not ':' in arg and not '/' in arg:
+                repos.append(arg)
+            else:
+                other_cmd_line_args.append(arg)
 
     remote_hosts = params.config.remote_hosts
 

--- a/mu_repo/action_clone.py
+++ b/mu_repo/action_clone.py
@@ -7,6 +7,13 @@ import os
 #===================================================================================================
 def Run(params):
     '''
+    Usage: 
+      Cloning one or multiple registered repositories
+      $mu clone repo-name [repo-name] ...
+      
+      Cloning all registered repositories
+      $mu clone --all
+    
     mu-repo can deal with cloning a repository and other referenced repositories recursively.
 
     To work this way, users are expected to commit the .mu_repo files they rely on and set

--- a/mu_repo/tests/test_clone.py
+++ b/mu_repo/tests/test_clone.py
@@ -90,3 +90,81 @@ class Test(unittest.TestCase):
 
             assert os.path.exists('projectC/.git')
             assert os.path.exists('projectC/.mu_repo')
+     
+
+    def test_clone_all(self):
+        git = 'git'
+
+        print(os.path.abspath('.'))
+        
+        remote_dir = 'test_temp_dir/remote_clone_all';
+
+        # Test diffing with new folder structure
+        subprocess.call([git] + ('init %s/meta_project' % (remote_dir)).split(), cwd='.')
+        subprocess.call([git] + ('init %s/projectD' % (remote_dir)).split(), cwd='.')
+        subprocess.call([git] + ('init %s/projectE' % (remote_dir)).split(), cwd='.')
+        subprocess.call([git] + ('init %s/projectF' % (remote_dir)).split(), cwd='.')
+
+        remote_base = os.path.realpath(os.path.abspath(remote_dir))
+        
+        # Register meta project repos
+        with open('%s/meta_project/.mu_repo' % (remote_dir), 'w') as stream:
+            stream.write('repo=projectD\nrepo=projectE\nrepo=projectF\n')
+            stream.write('remote_host=%s' % (remote_base))
+        
+        with self.push_dir(remote_base + '/meta_project'):            
+            configure_git_user()
+            mu_repo.main(config_file=None, args=['ac', 'Added projects'])
+            
+        # add some content to A
+        with open('%s/projectD/D.txt' % (remote_dir), 'w') as stream:
+            stream.write('some content of D')
+        # add some content to B
+        with open('%s/projectE/E.txt' % (remote_dir), 'w') as stream:
+            stream.write('some content of E')
+        # add some content to C
+        with open('%s/projectF/F.txt' % (remote_dir), 'w') as stream:
+            stream.write('some content of F')
+        
+        # Commit the changes
+        with self.push_dir(remote_base + '/projectD'):            
+            configure_git_user()
+            mu_repo.main(config_file=None, args=['ac', 'Initial commit'])
+            
+        with self.push_dir(remote_base + '/projectE'):
+            configure_git_user()
+            mu_repo.main(config_file=None, args=['ac', 'Initial commit'])
+
+        with self.push_dir(remote_base + '/projectF'):
+            configure_git_user()
+            mu_repo.main(config_file=None, args=['ac', 'Initial commit'])
+
+        makedirs('./test_temp_dir/local_clone_all')
+        
+        with self.push_dir('./test_temp_dir/local_clone_all'):
+            config = mu_repo.Config()
+            config.serial = True
+            config.remote_hosts = [remote_base]
+            mu_repo.main(config_file=None, args=['clone', 'meta_project'], config=config)
+            
+            with self.push_dir('./meta_project'):
+                mu_repo.main(args=['clone', '--all'])
+                
+                assert os.path.exists('projectD/.git')
+                assert os.path.exists('projectD/D.txt')
+
+                assert os.path.exists('projectE/.git')
+                assert os.path.exists('projectE/E.txt')
+
+                assert os.path.exists('projectF/.git')
+                assert os.path.exists('projectF/F.txt')
+             
+             
+#===================================================================================================
+# main
+#===================================================================================================
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testMuRepo']
+    unittest.main()
+           #assert os.path.exists('projectC/.mu_repo')
+           


### PR DESCRIPTION
clone --all will clone all registered repositories using the base remote host address. This is quite useful when registering a large number of repos and cloning them afterwards without specifying every single one.