### PR TITLE
Removed slash checking from repository name for cloning

### DIFF
--- a/mu_repo/action_clone.py
+++ b/mu_repo/action_clone.py
@@ -63,7 +63,7 @@ def Run(params):
         repos = params.config.repos
     else:
         for arg in args:
-            if not arg.startswith('-') and not '@' in arg and not ':' in arg and not '/' in arg:
+            if not arg.startswith('-') and not '@' in arg and not ':' in arg:
                 repos.append(arg)
             else:
                 other_cmd_line_args.append(arg)


### PR DESCRIPTION
This seems to work just fine. 
Fixes the first part of issue 42, but not the mentioned part about redirection and warnings. 