### PR TITLE
Register --recursive: Follow symlinks

### DIFF
--- a/mu_repo/tests/test_clone.py
+++ b/mu_repo/tests/test_clone.py
@@ -1,30 +1,18 @@
 from __future__ import with_statement
 
-from contextlib import contextmanager
 from os import makedirs
 import os.path
 import subprocess
 
 import mu_repo
 
-from .utils import configure_git_user
+from .utils import configure_git_user, push_dir
+_push_dir = push_dir
 
 
 def read(file2):
     with open(file2, 'r') as f:
         return f.read()
-
-
-@contextmanager
-def _push_dir(directory):
-    old = os.path.realpath(os.path.abspath(os.getcwd()))
-    new_dir = os.path.realpath(os.path.abspath(directory))
-    assert os.path.exists(new_dir)
-    os.chdir(new_dir)
-    try:
-        yield
-    finally:
-        os.chdir(old)
 
 
 def test_clone_with_deps():

--- a/mu_repo/tests/test_register.py
+++ b/mu_repo/tests/test_register.py
@@ -1,0 +1,79 @@
+import os
+
+import mu_repo
+from .utils import push_dir
+
+def set_up(workdir):
+    join = os.path.join
+    paths = {
+            'dir1':  join(workdir, 'projectA', 'sectionX'),
+            'dir2':  join(workdir, 'projectB', 'sectionY'),
+
+            'repo1': join(workdir, 'projectA', 'sectionX', 'repo1'),
+            'repo2': join(workdir, 'projectB', 'sectionY', 'repo2'),
+
+            'link1': join(workdir, 'projectA', 'sectionX', 'link1'),
+            'link2': join(workdir, 'projectB', 'sectionY', 'link2'),
+            }
+
+    # Mark repositories
+    os.makedirs(join(paths['repo1'], '.git'))
+    os.makedirs(join(paths['repo2'], '.git'))
+
+    return paths
+
+def test_direct_symlink(workdir):
+    """Linking directly to a repository inside of initial search path"""
+    paths = set_up(workdir)
+    os.symlink(paths['repo1'], paths['link1'])
+
+    with push_dir('projectA'):
+        status = mu_repo.main(config_file='.bar_file', args=['register', '--recursive'])
+
+    assert status.succeeded
+    assert status.config.repos == ['sectionX/repo1']
+
+def test_indirect_symlink(workdir):
+    """Linking to an ancestor of a repository"""
+    paths = set_up(workdir)
+    os.symlink(paths['dir1'], paths['link1'])
+
+    with push_dir('projectA'):
+        status = mu_repo.main(config_file='.bar_file', args=['register', '--recursive'])
+
+    assert status.succeeded
+    assert status.config.repos == ['sectionX/repo1']
+
+def test_search_path_expansion(workdir):
+    """Linking to a repository outside of initial search path"""
+    paths = set_up(workdir)
+    os.symlink(paths['repo2'], paths['link1'])
+
+    with push_dir('projectA'):
+        status = mu_repo.main(config_file='.bar_file', args=['register', '--recursive'])
+
+    assert status.succeeded
+    assert set(status.config.repos) == set(['sectionX/repo1', '../projectB/sectionY/repo2'])
+
+def test_infinite_cycle(workdir):
+    """Linking to own ancestor directory"""
+    paths = set_up(workdir)
+    os.symlink(paths['dir1'], paths['link1'])
+
+    with push_dir('projectA'):
+        status = mu_repo.main(config_file='.bar_file', args=['register', '--recursive'])
+
+    assert status.succeeded
+    assert status.config.repos == ['sectionX/repo1']
+
+def test_infinite_cycle_ouside(workdir):
+    """Linking to own ancestor directory in expanded search path"""
+    paths = set_up(workdir)
+    os.symlink(paths['dir2'], paths['link1'])
+    os.symlink(paths['dir2'], paths['link2'])
+
+    with push_dir('projectA'):
+        status = mu_repo.main(config_file='.bar_file', args=['register', '--recursive'])
+
+    assert status.succeeded
+    assert set(status.config.repos) == set(['sectionX/repo1', '../projectB/sectionY/repo2'])

--- a/mu_repo/tests/utils.py
+++ b/mu_repo/tests/utils.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+import os.path
 import subprocess
 
 
@@ -10,3 +12,17 @@ def configure_git_user(cwd='.'):
     subprocess.check_call('git config user.email testing@test.org',
                           cwd=cwd, shell=True)
     subprocess.check_call('git config user.name Testing', cwd=cwd, shell=True)
+
+
+@contextmanager
+def push_dir(directory):
+    old = os.path.realpath(os.path.abspath(os.getcwd()))
+    new_dir = os.path.realpath(os.path.abspath(directory))
+    assert os.path.exists(new_dir)
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+


### PR DESCRIPTION
This has the added bonus, that repositories which are directly
symlinked, are detected as already registered.

Fixes #43