### PR TITLE
Add 'git worktree add' custom support for mu-repo

### DIFF
--- a/mu_repo/__docs__.py
+++ b/mu_repo/__docs__.py
@@ -14,7 +14,7 @@
     Finds all branches matching a given pattern (or simply mu fb).
 * ${START_COLOR}mu git-init-config:${RESET_COLOR} Initial git configuration (username, log, etc.)
 * ${START_COLOR}mu --version:${RESET_COLOR} Prints its version
-* ${START_COLOR}mu worktreeadd {path} branch : ${RESET_COLOR}= git worktree {path} branch
+* ${START_COLOR}mu worktreeadd {path} branch : ${RESET_COLOR}= git worktree add {path} branch
     {path} is optional and defaults to a subfolder based on the branch name starting with _wt/ in the current directory.
     For example if branch 'release' was given, the path would be ./_wt/release
     The .murepo file is copied to the destination folder so that mu repo commands will work in the new worktree.
@@ -69,6 +69,7 @@ ${START_COLOR}mu ac msg     ${RESET_COLOR}= git add -A & git commit -m (the mess
 ${START_COLOR}mu acp msg    ${RESET_COLOR}= same as 'mu ac' + git push origin current branch.
 ${START_COLOR}mu p          ${RESET_COLOR}= git push origin current branch.
 ${START_COLOR}mu rb         ${RESET_COLOR}= git rebase origin/current branch.
+${START_COLOR}mu wtadd      ${RESET_COLOR}= see mu worktreeadd
 ${START_COLOR}mu shell      ${RESET_COLOR}= On msysgit, call sh --login -i (linux-like env)
 ${START_COLOR}mu fb [-r] pat${RESET_COLOR}= Shortcut for find-branch
 

--- a/mu_repo/__docs__.py
+++ b/mu_repo/__docs__.py
@@ -14,6 +14,11 @@
     Finds all branches matching a given pattern (or simply mu fb).
 * ${START_COLOR}mu git-init-config:${RESET_COLOR} Initial git configuration (username, log, etc.)
 * ${START_COLOR}mu --version:${RESET_COLOR} Prints its version
+* ${START_COLOR}mu worktreeadd {path} branch : ${RESET_COLOR}= git worktree {path} branch
+    {path} is optional and defaults to a subfolder based on the branch name starting with _wt/ in the current directory.
+    For example if branch 'release' was given, the path would be ./_wt/release
+    The .murepo file is copied to the destination folder so that mu repo commands will work in the new worktree.
+
 * ${START_COLOR}mu auto-update:${RESET_COLOR} Automatically updates mu-repo
   (using git -- if it was installed from the repo as in the instructions).
 

--- a/mu_repo/__init__.py
+++ b/mu_repo/__init__.py
@@ -265,6 +265,8 @@ def main(config_file=None, args=None, config=None):
 
     elif arg0 == 'rb':  # Rebase current_branch origin/current_branch
         from .action_rebase import Run  # @Reimport
+    elif arg0 in ('worktreeadd', 'wtadd'):  #  Add a new worktree
+        from .action_worktreeadd import Run  # @Reimport
 
 
     # assorted -------------------------------------------------------------------------------------

--- a/mu_repo/action_worktreeadd.py
+++ b/mu_repo/action_worktreeadd.py
@@ -30,14 +30,14 @@ def _WorktreeAdd(repos_and_branch, params):
     repos = []
     for repo, _branch in repos_and_branch:
         repos.append(repo)
-
+    
+    # sorting to improve odds with nested repos
+    # though if .murepo has things like ../../ in them it will throw things off
+    # TBD: might make sense to do abspath here in a sort lambda to be sure
     repos.sort(key = len)
-
-    Print(repos)
 
     for repo in repos:
         #Simple: Do git worktree add <base path> <branch> for all repos
-        Print([params.config.git, 'worktree', 'add', os.path.join(base_path,repo) , branch])
         commands.append(ParallelCmd(
             repo, [params.config.git, 'worktree', 'add', os.path.join(base_path,repo) , branch]))
 

--- a/mu_repo/action_worktreeadd.py
+++ b/mu_repo/action_worktreeadd.py
@@ -1,0 +1,63 @@
+import os
+from .execute_parallel_command import ParallelCmd, ExecuteInParallel, \
+    ExecuteInParallelStackingMessages
+from .get_repos_and_curr_branch import GetReposAndCurrBranch
+from .print_ import Print, PrintError, CreateJoinedReposMsg
+from shutil import copy2
+#===================================================================================================
+# _WorktreeAdd
+#===================================================================================================
+def _WorktreeAdd(repos_and_branch, params):
+    '''
+    :param repos_and_branch: list(tuple(str, str))
+    '''
+    commands = []
+
+    base_path = "_wt"
+    if ( len(params.args) > 2):
+        base_path = params.args[1]
+        branch = params.args[2]
+    else:
+        # Use _wt folder in the current repo
+        branch = params.args[1]
+
+    # always make sure the branch was added
+    if ( not branch in base_path ):
+        base_path = os.path.join(base_path, branch)
+
+    base_path = os.path.abspath(base_path)
+
+    repos = []
+    for repo, _branch in repos_and_branch:
+        repos.append(repo)
+
+    repos.sort(key = len)
+
+    Print(repos)
+
+    for repo in repos:
+        #Simple: Do git worktree add <base path> <branch> for all repos
+        Print([params.config.git, 'worktree', 'add', os.path.join(base_path,repo) , branch])
+        commands.append(ParallelCmd(
+            repo, [params.config.git, 'worktree', 'add', os.path.join(base_path,repo) , branch]))
+
+    # True for serial...may be creating nested repos which can break things
+    ExecuteInParallel(commands, None, True) 
+    # Need to copy .murepo file for the new worktree to work with mu-repo
+    copy2(params.config_file, base_path)
+
+
+#===================================================================================================
+# Run
+#===================================================================================================
+def Run(params):
+
+    repos_and_curr_branch = GetReposAndCurrBranch(params)
+
+    if ( len(params.args) < 2 ):
+        PrintError("worktreeadd needs a branch or base path and a branch")
+        raise
+
+    _WorktreeAdd(repos_and_curr_branch, params)
+
+    return repos_and_curr_branch


### PR DESCRIPTION
'mu worktree add...' does not produce usable results, this PR improves that behavior by using the repo relative path from the config to regenerate the repo structure in the worktree destination, as well as copying the .murepo to the new worktree so mu repo commands work as expected.

mu worktreeadd <branch>
will create a mu-repo copy of the currently active repo group in a subfolder of the current folder called _wt/<branch>

mu wtadd <path> <branch>   #wtadd is a shortcut name
will create a mu-repo copy of the currently active repo group in a subfolder of the specified folder called <branch>

git worktrees are great for having multiple copies of repos (always have a develop, master, release, and any number of feature branches for instance) as shallow copies with shared stashes.

Feel free to provide feedback or to take this PR and rework it as needed.