### PR TITLE
Add ability to find the remote_name and use it for a Bitbucket open-url

### DIFF
--- a/mu_repo/action_open_url.py
+++ b/mu_repo/action_open_url.py
@@ -1,5 +1,5 @@
 from mu_repo.print_ import Print
-
+import git
     
 
 #===================================================================================================
@@ -84,6 +84,7 @@ def Run(params):
                 repo = os.path.basename(os.path.realpath('.'))
             else:
                 repo = repo.replace('.', '').replace('/', '').replace('\\', '')
+            keywords['r_name'] = list(git.Repo(repo,search_parent_directories=True).remotes[0].urls)[0].split('/')[-1].split('.')[0]
             keywords['repo'] = repo
             url = pattern.format(**keywords)
             webbrowser.open_new_tab(url)


### PR DESCRIPTION
For reasons of legacy code I have directories with hard set names that do not match their bitbucket repository names. This lets me use {r_name} in a main-pattern to fix that.