### PR TITLE
Add new "copy group" command 

### DIFF
--- a/mu_repo/__docs__.py
+++ b/mu_repo/__docs__.py
@@ -42,6 +42,8 @@
 
   * ${START_COLOR}mu group add <name> [--empty]:${RESET_COLOR}
       Creates new group with current repositories, unless --empty is given
+  * ${START_COLOR}mu group add <name> --copy=<from>:${RESET_COLOR}
+      Creates new group with repositories copied from another group.
   * ${START_COLOR}mu group rm <name>:${RESET_COLOR} Removes a group
   * ${START_COLOR}mu group switch <name>:${RESET_COLOR} Switches to an existing group
   * ${START_COLOR}mu group reset:${RESET_COLOR} Stops using the current group (uses all repos again).

--- a/mu_repo/action_group.py
+++ b/mu_repo/action_group.py
@@ -17,7 +17,7 @@ def Run(params):
     msgs = []
     command = args[1] if len(args) > 1 else None
     group_name = args[2] if len(args) > 2 else None
-    clone_from = args[3] if len(args) > 3 else None
+    copy_from = args[3] if len(args) > 3 else None
 
     clean_new_group = '--clean' in args or '--empty' in args
 
@@ -40,7 +40,7 @@ def Run(params):
                 Print(msg)
                 msgs.append(msg)
 
-    elif command in ('add', 'clone'):
+    elif command in ('add', 'copy'):
         if group_name is None:
             msg = 'Group name not given.'
             Print(msg)
@@ -53,11 +53,11 @@ def Run(params):
 
         if clean_new_group:
             config.groups[group_name] = []
-        elif clone_from:
-            if clone_from in config.groups:
-                config.groups[group_name] = config.groups[clone_from]
+        elif copy_from:
+            if copy_from in config.groups:
+                config.groups[group_name] = config.groups[copy_from]
             else:
-                msg = 'Group to clone ${START_COLOR}%s{RESET_COLOR} does not exist' % clone_from
+                msg = 'Group to copy ${START_COLOR}%s{RESET_COLOR} does not exist' % copy_from
                 Print(msg)
                 return Status(msg, False)
         else:

--- a/mu_repo/action_group.py
+++ b/mu_repo/action_group.py
@@ -17,6 +17,7 @@ def Run(params):
     msgs = []
     command = args[1] if len(args) > 1 else None
     group_name = args[2] if len(args) > 2 else None
+    clone_from = args[3] if len(args) > 3 else None
 
     clean_new_group = '--clean' in args or '--empty' in args
 
@@ -39,7 +40,7 @@ def Run(params):
                 Print(msg)
                 msgs.append(msg)
 
-    elif command == 'add':
+    elif command in ('add', 'clone'):
         if group_name is None:
             msg = 'Group name not given.'
             Print(msg)
@@ -52,11 +53,18 @@ def Run(params):
 
         if clean_new_group:
             config.groups[group_name] = []
+        elif clone_from:
+            if clone_from in config.groups:
+                config.groups[group_name] = config.groups[clone_from]
+            else:
+                msg = 'Group to clone ${START_COLOR}%s{RESET_COLOR} does not exist' % clone_from
+                Print(msg)
+                return Status(msg, False)
         else:
             config.groups[group_name] = config.repos
 
         config.current_group = group_name
-
+    
     elif command in ('rm', 'del', 'switch', 'sw'):
         if group_name is None:
 

--- a/mu_repo/action_group.py
+++ b/mu_repo/action_group.py
@@ -20,7 +20,7 @@ def Run(params):
     
     clean_new_group = '--clean' in args or '--empty' in args
     copy_from = None
-    copy_arg =  next((x for x in args if x.startswith("--copy")), None)
+    copy_arg =  next((x for x in args if x.startswith("--copy=")), None)
     if copy_arg:
         copy_from = copy_arg.split("=")[1]
 
@@ -60,7 +60,7 @@ def Run(params):
             if copy_from in config.groups:
                 config.groups[group_name] = config.groups[copy_from]
             else:
-                msg = 'Group to copy ${START_COLOR}%s{RESET_COLOR} does not exist' % copy_from
+                msg = 'Group to copy ${START_COLOR}%s${RESET_COLOR} does not exist' % copy_from
                 Print(msg)
                 return Status(msg, False)
         else:

--- a/mu_repo/action_group.py
+++ b/mu_repo/action_group.py
@@ -17,9 +17,12 @@ def Run(params):
     msgs = []
     command = args[1] if len(args) > 1 else None
     group_name = args[2] if len(args) > 2 else None
-    copy_from = args[3] if len(args) > 3 else None
-
+    
     clean_new_group = '--clean' in args or '--empty' in args
+    copy_from = None
+    copy_arg =  next((x for x in args if x.startswith("--copy")), None)
+    if copy_arg:
+        copy_from = copy_arg.split("=")[1]
 
     if command != 'add' and clean_new_group:
         msg = '--clean and --empty only for "add" command'
@@ -40,7 +43,7 @@ def Run(params):
                 Print(msg)
                 msgs.append(msg)
 
-    elif command in ('add', 'copy'):
+    elif command == 'add':
         if group_name is None:
             msg = 'Group name not given.'
             Print(msg)

--- a/mu_repo/tests/test_mu_repo.py
+++ b/mu_repo/tests/test_mu_repo.py
@@ -127,8 +127,8 @@ def test_groups():
     assert status.config.current_group == 'group2'
     assert status.config.groups == {'group1' : ['pydev'], 'group2' : ['studio3']}
 
-    #clone group from pydev
-    status = mu_repo.main(config_file='.bar_file', args=['group','clone', 'pydev_bugfix', 'group1'])
+    #copy group from pydev
+    status = mu_repo.main(config_file='.bar_file', args=['group','copy', 'pydev_bugfix', 'group1'])
     assert status.config.repos == ['pydev', 'studio3']
     assert status.config.current_group == 'pydev_bugfix'
     assert status.config.groups == {'group1' : ['pydev'], 'group2' : ['studio3'], 'pydev_bugfix': ['pydev']}

--- a/mu_repo/tests/test_mu_repo.py
+++ b/mu_repo/tests/test_mu_repo.py
@@ -127,6 +127,13 @@ def test_groups():
     assert status.config.current_group == 'group2'
     assert status.config.groups == {'group1' : ['pydev'], 'group2' : ['studio3']}
 
+    #clone group from pydev
+    status = mu_repo.main(config_file='.bar_file', args=['group','clone', 'pydev_bugfix', 'group1'])
+    assert status.config.repos == ['pydev', 'studio3']
+    assert status.config.current_group == 'pydev_bugfix'
+    assert status.config.groups == {'group1' : ['pydev'], 'group2' : ['studio3'], 'pydev_bugfix': ['pydev']}
+
+
     status = mu_repo.main(config_file='.bar_file', args=['list', '@group1'])
     assert status.config.repos == ['pydev']
 
@@ -141,7 +148,7 @@ def test_groups():
     status = mu_repo.main(config_file='.bar_file', args=['group', 'del', 'group1'])
     assert status.config.repos == ['pydev', 'studio3']
     assert status.config.current_group == None
-    assert status.config.groups == {'group2' : ['studio3']}
+    assert status.config.groups == {'group2' : ['studio3'], 'pydev_bugfix': ['pydev']}
 
     # make sure state is to the rest of the application in other commands
 
@@ -160,7 +167,6 @@ def test_groups():
     status = mu_repo.main(config_file='.bar_file', args=['list'])
     assert status.config.repos == ['pydev', 'studio3']
     assert status.config.current_group == None
-
 
 def test_search_config_file_normal_case(workdir):
     """Test config search search works for the usual case up where the file is at the root of the repository."""

--- a/mu_repo/tests/test_mu_repo.py
+++ b/mu_repo/tests/test_mu_repo.py
@@ -128,7 +128,7 @@ def test_groups():
     assert status.config.groups == {'group1' : ['pydev'], 'group2' : ['studio3']}
 
     #copy group from pydev
-    status = mu_repo.main(config_file='.bar_file', args=['group','copy', 'pydev_bugfix', 'group1'])
+    status = mu_repo.main(config_file='.bar_file', args=['group','add', 'pydev_bugfix', '--copy=group1'])
     assert status.config.repos == ['pydev', 'studio3']
     assert status.config.current_group == 'pydev_bugfix'
     assert status.config.groups == {'group1' : ['pydev'], 'group2' : ['studio3'], 'pydev_bugfix': ['pydev']}


### PR DESCRIPTION
Use case:

I have many repositories under my git meta-repo.
I have created a set of "default" groups that I use to create easy to remember groups that represent certain recurring activities.
e.g.
group list:
 new   : group with repos most frequently occurring in "new feature" work
 bug_fix : group with repos most frequently occurring in "bug fix" work

I have found as I worked with this that sometimes the requirements change, and I want to add repos to the current working group. However, I don't want to make the change permanent, so I really just want to make a new group based on an existing group and make changes to that. Up til now, I've been doing it by hand editing the .mu_repo file, but I though maybe I could add a small feature to mu_repo that makes copying an existing repo an option.

usage:
mu group copy <new group name> <group to copy from>

example:
mu group copy new copy_group_feature

would take the existing "new" group and copy it into a new group called "copy_group_feature"

Unit Tests updated to reflect new feature.  