### PR TITLE
Enable development in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.7-slim
+
+RUN apt update && \
+    apt install --yes git
+
+RUN python3.7 -m pip install pytest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  test:
+    build:
+      context: .
+    volumes:
+      - .:/workarea
+    working_dir: /workarea
+    command: python3.7 -m pytest -vvv mu_repo/tests


### PR DESCRIPTION
For developers who do not have Python3.7 locally or want to ensure a consistent development experience, this minimal `Docker Compose` setup allows a developer to create a workspace and then work with the `mu_repo` project.

1. Create your workspace

`docker-compose build --pull`

2. Run tests

`docker-compose run --rm tests`

3. Get a shell

`docker-compose run --rm tests bash`